### PR TITLE
Release v0.0.4

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -1,0 +1,19 @@
+## Contributions are super welcome to improve the library API's scope, specially performance related changes. These are the few small guideline you need to follow.
+
+You can contribute by filing issues, bugs and PRs. You can also take a look at active issues and fix
+them.
+
+If you want to discuss something, then feel free to present your opinions, views or any other
+relevant comment on [Discussions](https://github.com/swapnil-musale/KDeviceInfo/discussions).
+
+### Code Contribution
+
+- Open issue to propose the change.
+- If your proposed change is approved, Fork this repo and do the changes.
+- Open PR, add nice description, showcase how to use, add demo in the form of screenshot or video
+  whatever applicable and if required update README file as well.
+
+### Code Contribution Checklist
+
+- New code addition/deletion should not break existing flow of a system.
+- Verify `./gradlew build` is passing before raising a PR.

--- a/KDeviceInfo/build.gradle.kts
+++ b/KDeviceInfo/build.gradle.kts
@@ -45,6 +45,7 @@ kotlin {
 
         androidMain.dependencies {
             implementation(libs.startup.runtime)
+            implementation(libs.androidx.core)
         }
     }
 

--- a/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/AndroidDeviceInfo.kt
+++ b/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/AndroidDeviceInfo.kt
@@ -8,28 +8,26 @@ import com.devx.kdeviceinfo.model.AndroidInfoImpl
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
 
-internal class AndroidDeviceInfoXState : DeviceInfoXState {
+actual class DeviceInfoXState {
 
     private lateinit var cachedAndroidInfo: AndroidInfo
 
-    override val androidInfo: AndroidInfo
+    actual val androidInfo: AndroidInfo
         get() {
             if (::cachedAndroidInfo.isInitialized.not()) {
                 cachedAndroidInfo = AndroidInfoImpl()
             }
             return cachedAndroidInfo
         }
-    override val iosInfo: IosInfo
+    actual val iosInfo: IosInfo
         get() = throw Exception("trying to access incorrect platform info")
-    override val isAndroid: Boolean
+    actual val isAndroid: Boolean
         get() = true
-    override val isIos: Boolean
+    actual val isIos: Boolean
         get() = false
 }
 
-actual fun DeviceInfoState(): DeviceInfoXState = AndroidDeviceInfoXState()
-
 @Composable
 actual fun rememberDeviceInfoXState(): DeviceInfoXState {
-    return remember { AndroidDeviceInfoXState() }
+    return remember { DeviceInfoXState() }
 }

--- a/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidDisplayMetricsImpl.kt
+++ b/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidDisplayMetricsImpl.kt
@@ -1,14 +1,9 @@
 package com.devx.kdeviceinfo.model
 
 import android.content.res.Resources
-import android.util.Log
 import com.devx.kdeviceinfo.model.android.DisplayMetrics
 
 internal class AndroidDisplayMetricsImpl : DisplayMetrics {
-
-    init {
-        Log.d("DeviceX", "${this.javaClass.name} Initialized")
-    }
 
     private val displayMetrics: android.util.DisplayMetrics? = Resources.getSystem().displayMetrics
     private val widthPx: Double = displayMetrics?.widthPixels?.toDouble() ?: 0.0

--- a/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidInfoImpl.kt
+++ b/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidInfoImpl.kt
@@ -4,19 +4,17 @@ import android.annotation.SuppressLint
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
+import androidx.core.app.LocaleManagerCompat
+import androidx.core.content.pm.PackageInfoCompat
 import com.devx.kdeviceinfo.initilizer.applicationContext
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.android.DisplayMetrics
 import com.devx.kdeviceinfo.model.android.Version
 import com.devx.kdeviceinfo.model.android.VersionCode
+import com.devx.kdeviceinfo.model.common.Locale
 
 internal class AndroidInfoImpl : AndroidInfo {
-
-    init {
-        Log.d("DeviceX", "${this.javaClass.name} Initialized")
-    }
 
     private val packageManager: PackageManager = applicationContext.packageManager
     private val packageInfo: PackageInfo =
@@ -92,6 +90,21 @@ internal class AndroidInfoImpl : AndroidInfo {
                 cachedAndroidVersionCode = AndroidVersionCodeImpl()
             }
             return cachedAndroidVersionCode
+        }
+
+    override val versionName: String
+        get() = packageInfo.versionName
+
+    override val versionCode: Long
+        get() = PackageInfoCompat.getLongVersionCode(packageInfo)
+
+    override val locale: Locale
+        get() {
+            val locale = LocaleManagerCompat.getSystemLocales(applicationContext).get(0)
+            return Locale(
+                languageCode = locale?.language.orEmpty(),
+                region = locale?.country.orEmpty()
+            )
         }
 
     private fun getIsPhysicalDevice(): Boolean {

--- a/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidVersionImpl.kt
+++ b/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidVersionImpl.kt
@@ -1,15 +1,10 @@
 package com.devx.kdeviceinfo.model
 
 import android.os.Build
-import android.util.Log
 import androidx.annotation.RequiresApi
 import com.devx.kdeviceinfo.model.android.Version
 
 internal class AndroidVersionImpl : Version {
-
-    init {
-        Log.d("DeviceX", "${this.javaClass.name} Initialized")
-    }
 
     override val baseOs: String
         @RequiresApi(Build.VERSION_CODES.M)

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXExt.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXExt.kt
@@ -19,14 +19,14 @@ fun OnPlatform(
     }
 }
 
-//fun onPlatform(
-//    onAndroid: ((AndroidInfo) -> Unit)? = null,
-//    onIos: ((IosInfo) -> Unit)? = null,
-//) {
-//    val deviceInfoXState = DeviceInfoState()
-//    if (deviceInfoXState.isAndroid) {
-//        onAndroid?.invoke(deviceInfoXState.androidInfo)
-//    } else {
-//        onIos?.invoke(deviceInfoXState.iosInfo)
-//    }
-//}
+fun onPlatform(
+    onAndroid: ((AndroidInfo) -> Unit)? = null,
+    onIos: ((IosInfo) -> Unit)? = null,
+) {
+    val deviceInfoXState = DeviceInfoXState()
+    if (deviceInfoXState.isAndroid) {
+        onAndroid?.invoke(deviceInfoXState.androidInfo)
+    } else {
+        onIos?.invoke(deviceInfoXState.iosInfo)
+    }
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXState.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXState.kt
@@ -6,14 +6,12 @@ import androidx.compose.runtime.Composable
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
 
-interface DeviceInfoXState {
+expect class DeviceInfoXState() {
     val isAndroid: Boolean
     val androidInfo: AndroidInfo
     val isIos: Boolean
     val iosInfo: IosInfo
 }
-
-expect fun DeviceInfoState(): DeviceInfoXState
 
 @Composable
 expect fun rememberDeviceInfoXState(): DeviceInfoXState

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/android/AndroidInfo.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/android/AndroidInfo.kt
@@ -2,6 +2,8 @@
 
 package com.devx.kdeviceinfo.model.android
 
+import com.devx.kdeviceinfo.model.common.Locale
+
 interface AndroidInfo {
     val appName: String
     val packageName: String
@@ -26,4 +28,7 @@ interface AndroidInfo {
     val displayMetrics: DisplayMetrics
     val serialNumber: String
     val VERSION_CODES: VersionCode
+    val versionName: String
+    val versionCode: Long
+    val locale: Locale
 }

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/common/Locale.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/common/Locale.kt
@@ -1,0 +1,6 @@
+package com.devx.kdeviceinfo.model.common
+
+data class Locale(
+    val languageCode: String,
+    val region: String
+)

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/ios/IosInfo.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/ios/IosInfo.kt
@@ -1,5 +1,7 @@
 package com.devx.kdeviceinfo.model.ios
 
+import com.devx.kdeviceinfo.model.common.Locale
+
 interface IosInfo {
     val name: String
     val systemName: String
@@ -11,4 +13,9 @@ interface IosInfo {
     val isMultitaskingSupported: Boolean
     val isGeneratingDeviceOrientationNotifications: Boolean
     val deviceOrientation: DeviceOrientation
+    val appName: String
+    val bundleId: String
+    val appVersion: String
+    val appShortVersion: String
+    val locale: Locale
 }

--- a/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/IosDeviceInfo.kt
+++ b/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/IosDeviceInfo.kt
@@ -8,28 +8,26 @@ import com.devx.kdeviceinfo.model.IosInfoImpl
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
 
-internal class IosDeviceInfoXState : DeviceInfoXState {
+actual class DeviceInfoXState {
 
     private lateinit var cachedIosInfo: IosInfo
 
-    override val androidInfo: AndroidInfo
+    actual val androidInfo: AndroidInfo
         get() = throw Exception("trying to access incorrect platform info")
-    override val iosInfo: IosInfo
+    actual val iosInfo: IosInfo
         get() {
             if (::cachedIosInfo.isInitialized.not()) {
                 cachedIosInfo = IosInfoImpl()
             }
             return cachedIosInfo
         }
-    override val isAndroid: Boolean
+    actual val isAndroid: Boolean
         get() = false
-    override val isIos: Boolean
+    actual val isIos: Boolean
         get() = true
 }
 
-actual fun DeviceInfoState(): DeviceInfoXState = IosDeviceInfoXState()
-
 @Composable
 actual fun rememberDeviceInfoXState(): DeviceInfoXState {
-    return remember { IosDeviceInfoXState() }
+    return remember { DeviceInfoXState() }
 }

--- a/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/model/IosInfoImpl.kt
+++ b/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/model/IosInfoImpl.kt
@@ -1,8 +1,14 @@
 package com.devx.kdeviceinfo.model
 
+import com.devx.kdeviceinfo.model.common.Locale
 import com.devx.kdeviceinfo.model.ios.DeviceOrientation
 import com.devx.kdeviceinfo.model.ios.IosInfo
+import platform.Foundation.NSBundle
+import platform.Foundation.NSLocale
 import platform.Foundation.NSProcessInfo
+import platform.Foundation.currentLocale
+import platform.Foundation.languageCode
+import platform.Foundation.regionCode
 import platform.UIKit.UIDevice
 
 internal class IosInfoImpl : IosInfo {
@@ -21,7 +27,6 @@ internal class IosInfoImpl : IosInfo {
         get() = UIDevice.currentDevice.localizedModel
     override val identifierForVendor: String
         get() = UIDevice.currentDevice.identifierForVendor?.UUIDString.orEmpty()
-
     override val isPhysicalDevice: Boolean
         get() = NSProcessInfo.processInfo.environment["SIMULATOR_UDID"] == null
     override val isMultitaskingSupported: Boolean
@@ -35,4 +40,18 @@ internal class IosInfoImpl : IosInfo {
             }
             return cachedDeviceOrientation
         }
+    override val appName: String
+        get() = (NSBundle.mainBundle.infoDictionary?.get("CFBundleDisplayName")
+            ?: NSBundle.mainBundle.infoDictionary?.get("CFBundleName")) as String
+    override val bundleId: String
+        get() = NSBundle.mainBundle.bundleIdentifier.orEmpty()
+    override val appVersion: String
+        get() = NSBundle.mainBundle.infoDictionary?.get("CFBundleVersion") as String
+    override val appShortVersion: String
+        get() = NSBundle.mainBundle.infoDictionary?.get("CFBundleShortVersionString") as String
+    override val locale: Locale
+        get() = Locale(
+            languageCode = NSLocale.currentLocale.languageCode,
+            region = NSLocale.currentLocale.regionCode.orEmpty()
+        )
 }

--- a/README.MD
+++ b/README.MD
@@ -7,6 +7,7 @@ ios devices without writing expect actual boilerplate code.
 <a href="https://github.com/swapnil-musale/KDeviceInfo"><img alt="Android" src="https://img.shields.io/badge/Platform-Android-Blue?style=for-the-badge"/></a>
 <a href="https://github.com/swapnil-musale/KDeviceInfo"><img alt="Ios" src="https://img.shields.io/badge/Platform-Ios-Blue?style=for-the-badge"/></a>
 <a href="https://github.com/swapnil-musale/KDeviceInfo"><img alt="Maven Central" src="https://img.shields.io/maven-central/v/io.github.swapnil-musale/KDeviceInfo?style=for-the-badge"/></a>
+<a href="https://github.com/swapnil-musale/KDeviceInfo"><img alt="CI Status" src="https://img.shields.io/github/actions/workflow/status/swapnil-musale/KDeviceInfo/build.yml?style=for-the-badge"/></a>
 
 # Demo ❤️
 
@@ -65,11 +66,7 @@ fun DeviceInfoExample() {
 
     val deviceInfoXState: DeviceInfoXState = rememberDeviceInfoXState()
     
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .windowInsetsPadding(insets = WindowInsets.safeDrawing)
-    ) {
+    Column(modifier = Modifier.fillMaxSize()) {
         if (deviceInfoXState.isAndroid) {
             val androidInfo = deviceInfoXState.androidInfo
             Text(text = "App Name : ${androidInfo.appName}")
@@ -85,21 +82,64 @@ fun DeviceInfoExample() {
 }
 ```
 
+**OR** Use helper function to access device information
+
+```
+@Composable
+fun DeviceInfoExample() {
+    Column(modifier = Modifier.fillMaxSize()) {
+        OnPlatform(
+            onAndroid = { androidInfo ->
+                Text(text = "App Name : ${androidInfo.appName}")
+                Text(text = "SdkInt : ${androidInfo.version.sdkInt}")
+                Text(text = "PackageName : ${androidInfo.packageName}")
+            },
+            onIos = { iosInfo ->
+                Text(text = "SystemName : ${iosInfo.systemName}")
+                Text(text = "SystemVersion : ${iosInfo.systemVersion}")
+                Text(text = "IsPhysicalDevice : ${iosInfo.isPhysicalDevice}")
+            }
+        )
+    }
+}
+```
+
 To access the device details outside the Composable function you can make use of **DeviceInfoState** as below
 
 ```
 class AppViewModel {
 
-    private val deviceInfoXState: DeviceInfoXState = DeviceInfoState()
+    private val deviceInfoXState: DeviceInfoXState = DeviceInfoXState()
 
     init {
         if (deviceInfoXState.isAndroid) {
             val androidInfo: AndroidInfo = deviceInfoXState.androidInfo
             println("DeviceInfoX - App Name : ${androidInfo.appName}")
+            println("DeviceInfoX - App Name : ${androidInfo.versionName}")
         } else {
             val iosInfo: IosInfo = deviceInfoXState.iosInfo
-            println("DeviceInfoX - System Name : ${iosInfo.systemName}")
+            println("DeviceInfoX - System Name : ${iosInfo.appName}")
+            println("DeviceInfoX - System Name : ${iosInfo.appVersion}")
         }
+    }
+}
+```
+
+**OR** Use helper function to access device information
+
+```
+class AppViewModel {
+    init {
+        onPlatform(
+            onAndroid = { androidInfo ->
+                println("DeviceInfoX - App Name : ${androidInfo.appName}")
+                println("DeviceInfoX - App Name : ${androidInfo.versionName}")
+            },
+            onIos = { iosInfo ->
+                println("DeviceInfoX - System Name : ${iosInfo.appName}")
+                println("DeviceInfoX - System Name : ${iosInfo.appVersion}")
+            }
+        )
     }
 }
 ```
@@ -109,18 +149,21 @@ Compose Multiplatform project check out [Sample App][0].
 
 # Contributions
 
-Contributions to KDeviceInfo are welcome. If you encounter any issues or have suggestions for
+Contributions to KDeviceInfo are super welcome checkout [Contributions Guidelines][4]. If you encounter any issues or have suggestions for
 improvements, please feel free to open an issue or submit a pull request on GitHub.
 
-## Connect with me:
+## Connect with me
 
 [![Github Profile](https://skillicons.dev/icons?i=github)][1]
 [![LinkedIn](https://skillicons.dev/icons?i=linkedin)][2]
+[![Twitter](https://skillicons.dev/icons?i=twitter)][3]
 
 
 [0]: https://github.com/swapnil-musale/KDeviceInfo/tree/read_me/sampleApp
 [1]: https://github.com/swapnil-musale
 [2]: https://linkedin.com/in/swapnil-musale
+[3]: https://twitter.com/swapnil_musale
+[4]: https://github.com/swapnil-musale/KDeviceInfo/blob/master/CONTRIBUTING.MD
 
 # Licence
 

--- a/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/convention.publication.gradle.kts
@@ -87,6 +87,7 @@ publishing {
                 name.set("KDeviceInfo")
                 description.set("KDeviceInfo is Kotlin Multiplatform library to access the device info without writing the boilerplate code")
                 url.set("https://github.com/swapnil-musale/KDeviceInfo")
+                inceptionYear = "2024"
 
                 licenses {
                     license {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,13 +8,13 @@ jetbrainsCompose = "1.5.12"
 annotation = "1.7.1"
 startupRuntime = "1.1.1"
 androidXCore = "1.12.0"
-kDeviceInfoLibraryVersion = "0.0.3"
+kDeviceInfoLibraryVersion = "0.0.4"
 
 # sampleApp Versions
 androidxAppcompat = "1.6.1"
 androidxActivityCompose = "1.8.2"
 androidXCompose = "1.6.1"
-kDeviceInfo = "0.0.3"
+kDeviceInfo = "0.0.4"
 
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ jetbrainsCompose = "1.5.12"
 # Library Versions
 annotation = "1.7.1"
 startupRuntime = "1.1.1"
+androidXCore = "1.12.0"
 kDeviceInfoLibraryVersion = "0.0.3"
 
 # sampleApp Versions
@@ -22,6 +23,7 @@ androidx-annotation = { module = "androidx.annotation:annotation", version.ref =
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jetbrainsCompose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrainsCompose" }
 startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "startupRuntime" }
+androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidXCore" }
 
 # sampleApp module libraries
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }

--- a/sampleApp/composeApp/build.gradle.kts
+++ b/sampleApp/composeApp/build.gradle.kts
@@ -28,8 +28,8 @@ kotlin {
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.material3)
-            implementation(libs.kDeviceinfo)
-//            implementation(projects.kDeviceInfo)
+//            implementation(libs.kDeviceinfo)
+            implementation(projects.kDeviceInfo)
         }
 
         androidMain.dependencies {

--- a/sampleApp/composeApp/build.gradle.kts
+++ b/sampleApp/composeApp/build.gradle.kts
@@ -28,8 +28,8 @@ kotlin {
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.material3)
-//            implementation(libs.kDeviceinfo)
-            implementation(projects.kDeviceInfo)
+            implementation(libs.kDeviceinfo)
+//            implementation(projects.kDeviceInfo)
         }
 
         androidMain.dependencies {

--- a/sampleApp/composeApp/src/androidMain/AndroidManifest.xml
+++ b/sampleApp/composeApp/src/androidMain/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application
         android:name=".AndroidApp"
         android:icon="@android:drawable/ic_menu_compass"
-        android:label="sampleApp"
+        android:label="KDeviceInfo"
         android:theme="@style/Theme.AppCompat.DayNight.NoActionBar">
         <activity
             android:name=".AppActivity"

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
@@ -1,11 +1,8 @@
 package com.devx.kdeviceinfo.sample
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.safeDrawing
-import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -33,8 +30,8 @@ internal fun App() = AppTheme {
         Column(
             modifier = Modifier
                 .fillMaxSize()
+                .padding(paddingValues = it)
                 .padding(horizontal = 16.dp)
-                .windowInsetsPadding(insets = WindowInsets.safeDrawing),
         ) {
             if (deviceInfoXState.isAndroid) {
                 ShowAndroidDeviceInfo(androidInfo = deviceInfoXState.androidInfo)
@@ -50,6 +47,10 @@ private fun ShowAndroidDeviceInfo(androidInfo: AndroidInfo) {
     val verticalScrollState = rememberScrollState()
 
     Column(modifier = Modifier.verticalScroll(state = verticalScrollState)) {
+        Text(text = "Language Code : ${androidInfo.locale.languageCode}")
+        Text(text = "Region : ${androidInfo.locale.region}")
+        Text(text = "Version Code : ${androidInfo.versionCode}")
+        Text(text = "Version Name : ${androidInfo.versionName}")
         Text(text = "Device : ${androidInfo.device}")
         Text(text = "SdkInt : ${androidInfo.version.sdkInt}")
         Text(text = "BaseOs : ${androidInfo.version.baseOs}")
@@ -82,6 +83,12 @@ private fun ShowIosDeviceInfo(iosInfo: IosInfo) {
     val verticalScrollState = rememberScrollState()
 
     Column(modifier = Modifier.verticalScroll(state = verticalScrollState)) {
+        Text(text = "Language Code : ${iosInfo.locale.languageCode}")
+        Text(text = "Region : ${iosInfo.locale.region}")
+        Text(text = "App Name : ${iosInfo.appName}")
+        Text(text = "Bundle Id : ${iosInfo.bundleId}")
+        Text(text = "App Version : ${iosInfo.appVersion}")
+        Text(text = "App Short Version : ${iosInfo.appShortVersion}")
         Text(text = "Name : ${iosInfo.name}")
         Text(text = "Model : ${iosInfo.model}")
         Text(text = "SystemName : ${iosInfo.systemName}")

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
@@ -53,28 +53,14 @@ private fun ShowAndroidDeviceInfo(androidInfo: AndroidInfo) {
         Text(text = "Version Name : ${androidInfo.versionName}")
         Text(text = "Device : ${androidInfo.device}")
         Text(text = "SdkInt : ${androidInfo.version.sdkInt}")
-        Text(text = "BaseOs : ${androidInfo.version.baseOs}")
         Text(text = "Release : ${androidInfo.version.release}")
         Text(text = "App Name : ${androidInfo.appName}")
         Text(text = "Package Name : ${androidInfo.packageName}")
-        Text(text = "SecurityPatch : ${androidInfo.version.securityPatch}")
-        Text(text = "previewSdkInt : ${androidInfo.version.previewSdkInt}")
-        Text(text = "ReleaseOrCodeName : ${androidInfo.version.releaseOrCodeName}")
-        Text(text = "MediaPerformanceClass : ${androidInfo.version.mediaPerformanceClass}")
-        Text(text = "Incremental : ${androidInfo.version.incremental}")
-        Text(text = "ReleaseOrPreviewDisplay : ${androidInfo.version.releaseOrPreviewDisplay}")
         Text(text = "CodeName : ${androidInfo.version.codeName}")
         Text(text = "Board : ${androidInfo.board}")
-        Text(text = "Bootloader : ${androidInfo.bootloader}")
-        Text(text = "Display : ${androidInfo.display}")
-        Text(text = "Fingerprint : ${androidInfo.fingerprint}")
-        Text(text = "Hardware : ${androidInfo.hardware}")
-        Text(text = "Host : ${androidInfo.host}")
-        Text(text = "Id : ${androidInfo.id}")
         Text(text = "IsPhysicalDevice : ${androidInfo.isPhysicalDevice}")
         Text(text = "Manufacturer : ${androidInfo.manufacturer}")
         Text(text = "Model : ${androidInfo.model}")
-        Text(text = "Product : ${androidInfo.product}")
     }
 }
 
@@ -95,9 +81,6 @@ private fun ShowIosDeviceInfo(iosInfo: IosInfo) {
         Text(text = "SystemVersion : ${iosInfo.systemVersion}")
         Text(text = "LocalizedModel : ${iosInfo.localizedModel}")
         Text(text = "IsPhysicalDevice : ${iosInfo.isPhysicalDevice}")
-        Text(text = "IdentifierForVendor : ${iosInfo.identifierForVendor}")
-        Text(text = "IsMultitaskingSupported : ${iosInfo.isMultitaskingSupported}")
-        Text(text = "IsGeneratingDeviceOrientationNotifications : ${iosInfo.isGeneratingDeviceOrientationNotifications}")
         Text(text = "DeviceOrientation : ${iosInfo.deviceOrientation.getDeviceOrientation()}")
     }
 }

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/AppViewModel.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/AppViewModel.kt
@@ -1,13 +1,12 @@
 package com.devx.kdeviceinfo.sample
 
-import com.devx.kdeviceinfo.DeviceInfoState
 import com.devx.kdeviceinfo.DeviceInfoXState
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
 
 class AppViewModel {
 
-    private val deviceInfoXState: DeviceInfoXState = DeviceInfoState()
+    private val deviceInfoXState: DeviceInfoXState = DeviceInfoXState()
 
     init {
         if (deviceInfoXState.isAndroid) {

--- a/sampleApp/iosApp/iosApp.xcodeproj/project.pbxproj
+++ b/sampleApp/iosApp/iosApp.xcodeproj/project.pbxproj
@@ -301,6 +301,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = KDeviceInfo;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -341,6 +342,7 @@
 				);
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = iosApp/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = KDeviceInfo;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;

--- a/sampleApp/iosApp/iosApp/Info.plist
+++ b/sampleApp/iosApp/iosApp/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>KDeviceInfo</string>
 	<key>CFBundlePackageType</key>
 	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
 	<key>CFBundleShortVersionString</key>


### PR DESCRIPTION
In this release adding support few more device information to be accessible with ```v0.0.4```

For Android Platfom :
1. versionName
2. versionCode
3. locale

For iOS Platform : 
1. appName
2. bundleId
3. appVersion
4. appShortVersion

Other Changes : 
1. Change sample app name
2. Convert ```DeviceInfoXState``` from interface to expect class
3. Remove logs when *Impl class instantiates
4. Add helper function to access device information from non composable context