### PR TITLE
Add support to check build variant

### DIFF
--- a/KDeviceInfo/build.gradle.kts
+++ b/KDeviceInfo/build.gradle.kts
@@ -74,6 +74,9 @@ android {
     defaultConfig {
         minSdk = 21
     }
+    buildFeatures {
+        buildConfig = true
+    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17

--- a/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidInfoImpl.kt
+++ b/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/model/AndroidInfoImpl.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.provider.Settings
 import androidx.core.app.LocaleManagerCompat
 import androidx.core.content.pm.PackageInfoCompat
+import com.devx.kdeviceinfo.BuildConfig
 import com.devx.kdeviceinfo.initilizer.applicationContext
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.android.DisplayMetrics
@@ -110,6 +111,9 @@ internal class AndroidInfoImpl : AndroidInfo {
             applicationContext.contentResolver,
             Settings.Secure.ANDROID_ID
         )
+
+    override val isDebug: Boolean
+        get() = BuildConfig.DEBUG
 
     private fun getIsPhysicalDevice(): Boolean {
         return !((Build.BRAND.startsWith("generic") && Build.DEVICE.startsWith("generic"))

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/android/AndroidInfo.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/android/AndroidInfo.kt
@@ -33,4 +33,5 @@ interface AndroidInfo {
     val locale: Locale
     val deviceOrientation: DeviceOrientation
     val androidId: String
+    val isDebug: Boolean
 }

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/ios/IosInfo.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/ios/IosInfo.kt
@@ -19,4 +19,5 @@ interface IosInfo {
     val appVersion: String
     val appShortVersion: String
     val locale: Locale
+    val isDebug: Boolean
 }

--- a/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/model/IosInfoImpl.kt
+++ b/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/model/IosInfoImpl.kt
@@ -10,6 +10,7 @@ import platform.Foundation.currentLocale
 import platform.Foundation.languageCode
 import platform.Foundation.regionCode
 import platform.UIKit.UIDevice
+import kotlin.experimental.ExperimentalNativeApi
 
 internal class IosInfoImpl : IosInfo {
 
@@ -51,4 +52,8 @@ internal class IosInfoImpl : IosInfo {
             languageCode = NSLocale.currentLocale.languageCode,
             region = NSLocale.currentLocale.regionCode.orEmpty()
         )
+
+    @OptIn(ExperimentalNativeApi::class)
+    override val isDebug: Boolean
+        get() = Platform.isDebugBinary
 }

--- a/sampleApp/composeApp/build.gradle.kts
+++ b/sampleApp/composeApp/build.gradle.kts
@@ -63,6 +63,11 @@ android {
         versionCode = 1
         versionName = "1.0.0"
     }
+    buildTypes {
+        getByName("release") {
+            signingConfig = signingConfigs.getByName("debug")
+        }
+    }
     sourceSets["main"].apply {
         manifest.srcFile("src/androidMain/AndroidManifest.xml")
         res.srcDirs("src/androidMain/resources")

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
@@ -60,6 +60,7 @@ private fun ShowAndroidDeviceInfo(androidInfo: AndroidInfo) {
         Text(text = "Version Code : ${androidInfo.versionCode}")
         Text(text = "Version Name : ${androidInfo.versionName}")
         Text(text = "Package Name : ${androidInfo.packageName}")
+        Text(text = "Debug App : ${androidInfo.isDebug}")
         Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
 
         // Device Info
@@ -97,6 +98,7 @@ private fun ShowIosDeviceInfo(iosInfo: IosInfo) {
         Text(text = "App Version : ${iosInfo.appVersion}")
         Text(text = "App Short Version : ${iosInfo.appShortVersion}")
         Text(text = "Bundle Id : ${iosInfo.bundleId}")
+        Text(text = "Debug App : ${iosInfo.isDebug}")
         Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
 
         // Device Info


### PR DESCRIPTION
In this PR we've exposed field property to check is app is running on `debug` or `release` build variant. In some cases we have to provide different implementation when app is running in `debug` or `release` mode. 

This is how user can access build variant property : 

- **Android** : `androidInfo.isDebug`
- **Ios** : `iosInfo.isDebug`

Resolves : #39 