### PR TITLE
wasm target integration

### DIFF
--- a/KDeviceInfo/build.gradle.kts
+++ b/KDeviceInfo/build.gradle.kts
@@ -47,7 +47,7 @@ kotlin {
         browser {
             webpackTask {
                 dependencies {
-                    implementation(libs.x.cdn.jsdelivr.net.npm.ua.parser.js)
+                    implementation(npm("ua-parser-js", "2.0.0"))
                 }
             }
         }

--- a/KDeviceInfo/build.gradle.kts
+++ b/KDeviceInfo/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.kotlin.gradle.ExperimentalWasmDsl
 import org.jetbrains.kotlin.gradle.dsl.KotlinCommonCompile
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
@@ -39,6 +40,19 @@ kotlin {
         }
     }
 
+    // Web (WASM JavaScript)
+    @OptIn(ExperimentalWasmDsl::class)
+    wasmJs {
+        binaries.executable()
+        browser {
+            webpackTask {
+                dependencies {
+                    implementation(libs.x.cdn.jsdelivr.net.npm.ua.parser.js)
+                }
+            }
+        }
+    }
+
     sourceSets {
         commonMain.dependencies {
             implementation(libs.compose.ui)
@@ -53,7 +67,7 @@ kotlin {
 
         val desktopMain by getting {
             dependencies {
-                implementation("com.github.oshi:oshi-core:6.6.5")
+                implementation(libs.oshi.core)
             }
         }
 

--- a/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/AndroidDeviceInfo.kt
+++ b/KDeviceInfo/src/androidMain/kotlin/com/devx/kdeviceinfo/AndroidDeviceInfo.kt
@@ -9,6 +9,7 @@ import com.devx.kdeviceinfo.model.AndroidInfoImpl
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
+import com.devx.kdeviceinfo.model.web.WebInfo
 
 actual class DeviceInfoXState {
 
@@ -33,6 +34,13 @@ actual class DeviceInfoXState {
 
     actual val desktopInfo: DesktopInfo
         get() = throw Exception("trying to access incorrect platform info")
+
+    actual val webInfo: WebInfo
+        get() = throw Exception("trying to access incorrect platform info")
+
+    actual val isWeb: Boolean
+        get() = false
+
 }
 
 @Composable

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXExt.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXExt.kt
@@ -4,29 +4,43 @@ package com.devx.kdeviceinfo
 
 import androidx.compose.runtime.Composable
 import com.devx.kdeviceinfo.model.android.AndroidInfo
+import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
+import com.devx.kdeviceinfo.model.web.WebInfo
 
 @Composable
 fun OnPlatform(
+    deviceInfoXState: DeviceInfoXState = rememberDeviceInfoXState(),
     onAndroid: @Composable ((AndroidInfo) -> Unit)? = null,
     onIos: @Composable ((IosInfo) -> Unit)? = null,
+    onDesktop: @Composable ((DesktopInfo) -> Unit)? = null,
+    onWeb: @Composable ((WebInfo) -> Unit)? = null,
 ) {
-    val deviceInfoXState = rememberDeviceInfoXState()
     if (deviceInfoXState.isAndroid) {
         onAndroid?.invoke(deviceInfoXState.androidInfo)
-    } else {
+    } else if(deviceInfoXState.isIos){
         onIos?.invoke(deviceInfoXState.iosInfo)
+    } else if(deviceInfoXState.isDesktop) {
+        onDesktop?.invoke(deviceInfoXState.desktopInfo)
+    } else {
+        onWeb?.invoke(deviceInfoXState.webInfo)
     }
 }
 
 fun onPlatform(
+    deviceInfoXState: DeviceInfoXState = DeviceInfoXState(),
     onAndroid: ((AndroidInfo) -> Unit)? = null,
     onIos: ((IosInfo) -> Unit)? = null,
+    onDesktop: ((DesktopInfo) -> Unit)? = null,
+    onWeb: ((WebInfo) -> Unit)? = null
 ) {
-    val deviceInfoXState = DeviceInfoXState()
     if (deviceInfoXState.isAndroid) {
         onAndroid?.invoke(deviceInfoXState.androidInfo)
-    } else if (deviceInfoXState.isIos) {
+    } else if(deviceInfoXState.isIos){
         onIos?.invoke(deviceInfoXState.iosInfo)
+    } else if(deviceInfoXState.isDesktop) {
+        onDesktop?.invoke(deviceInfoXState.desktopInfo)
+    } else {
+        onWeb?.invoke(deviceInfoXState.webInfo)
     }
 }

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXState.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXState.kt
@@ -6,6 +6,7 @@ import androidx.compose.runtime.Composable
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
+import com.devx.kdeviceinfo.model.web.WebInfo
 
 expect class DeviceInfoXState() {
     val isAndroid: Boolean
@@ -14,6 +15,8 @@ expect class DeviceInfoXState() {
     val iosInfo: IosInfo
     val isDesktop: Boolean
     val desktopInfo: DesktopInfo
+    val webInfo: WebInfo
+    val isWeb: Boolean
 }
 
 @Composable

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/WebInfo.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/WebInfo.kt
@@ -1,0 +1,16 @@
+package com.devx.kdeviceinfo.model.web
+
+import com.devx.kdeviceinfo.model.web.browser.Browser
+import com.devx.kdeviceinfo.model.web.cpu.CPU
+import com.devx.kdeviceinfo.model.web.device.Device
+import com.devx.kdeviceinfo.model.web.engine.Engine
+import com.devx.kdeviceinfo.model.web.operatingsystem.Os
+
+interface WebInfo {
+    val userAgent: String
+    val browser: Browser
+    val cpu: CPU
+    val device: Device
+    val engine: Engine
+    val os: Os
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/WebInfoItem.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/WebInfoItem.kt
@@ -1,0 +1,25 @@
+package com.devx.kdeviceinfo.model.web
+
+interface WebInfoItem {
+
+    companion object {
+
+        /**
+         * **UKNOWN** -> the uknown value to use when the specific information has not found
+         */
+        private const val UKNOWN = "uknown"
+    }
+
+    /**
+     * Method to use a null-safe value
+     *
+     * @return the found value or the [UKNOWN] value as [String]
+     */
+    fun String?.safeValue(): String {
+        return if (this != null)
+            this
+        else
+            UKNOWN
+    }
+
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/browser/Browser.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/browser/Browser.kt
@@ -1,0 +1,8 @@
+package com.devx.kdeviceinfo.model.web.browser
+
+import com.devx.kdeviceinfo.model.web.WebInfoItem
+
+interface Browser : WebInfoItem {
+    val name: String
+    val version: String
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/cpu/CPU.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/cpu/CPU.kt
@@ -1,0 +1,7 @@
+package com.devx.kdeviceinfo.model.web.cpu
+
+import com.devx.kdeviceinfo.model.web.WebInfoItem
+
+interface CPU : WebInfoItem {
+    val architecture: String
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/device/Device.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/device/Device.kt
@@ -1,0 +1,9 @@
+package com.devx.kdeviceinfo.model.web.device
+
+import com.devx.kdeviceinfo.model.web.WebInfoItem
+
+interface Device : WebInfoItem {
+    val model: String
+    val type: String
+    val vendor: String
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/engine/Engine.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/engine/Engine.kt
@@ -1,0 +1,8 @@
+package com.devx.kdeviceinfo.model.web.engine
+
+import com.devx.kdeviceinfo.model.web.WebInfoItem
+
+interface Engine : WebInfoItem {
+    val name: String
+    val version: String
+}

--- a/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/operatingsystem/Os.kt
+++ b/KDeviceInfo/src/commonMain/kotlin/com/devx/kdeviceinfo/model/web/operatingsystem/Os.kt
@@ -1,0 +1,8 @@
+package com.devx.kdeviceinfo.model.web.operatingsystem
+
+import com.devx.kdeviceinfo.model.web.WebInfoItem
+
+interface Os : WebInfoItem {
+    val name: String
+    val version: String
+}

--- a/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/IosDeviceInfo.kt
+++ b/KDeviceInfo/src/iosMain/kotlin/com/devx/kdeviceinfo/IosDeviceInfo.kt
@@ -9,6 +9,7 @@ import com.devx.kdeviceinfo.model.IosInfoImpl
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
+import com.devx.kdeviceinfo.model.web.WebInfo
 import platform.UIKit.interfaceOrientation
 
 actual class DeviceInfoXState {
@@ -34,6 +35,13 @@ actual class DeviceInfoXState {
 
     actual val desktopInfo: DesktopInfo
         get() = throw Exception("trying to access incorrect platform info")
+
+    actual val webInfo: WebInfo
+        get() = throw Exception("trying to access incorrect platform info")
+
+    actual val isWeb: Boolean
+        get() = false
+
 }
 
 @Composable

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXState.wasmJs.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/DeviceInfoXState.wasmJs.kt
@@ -1,9 +1,7 @@
-@file:Suppress("unused")
-
 package com.devx.kdeviceinfo
 
 import androidx.compose.runtime.Composable
-import com.devx.kdeviceinfo.model.DesktopInfoImpl
+import com.devx.kdeviceinfo.model.WebInfoImpl
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
@@ -11,15 +9,15 @@ import com.devx.kdeviceinfo.model.web.WebInfo
 
 actual class DeviceInfoXState {
 
-    private val desktopInfoData: DesktopInfo by lazy {
-        DesktopInfoImpl()
+    private val webInfoData: WebInfo by lazy {
+        WebInfoImpl()
     }
 
     actual val isDesktop: Boolean
-        get() = true
+        get() = false
 
     actual val desktopInfo: DesktopInfo
-        get() = desktopInfoData
+        get() = throw Exception("trying to access incorrect platform info")
 
     actual val isAndroid: Boolean
         get() = false
@@ -34,10 +32,10 @@ actual class DeviceInfoXState {
         get() = throw Exception("trying to access incorrect platform info")
 
     actual val webInfo: WebInfo
-        get() = throw Exception("trying to access incorrect platform info")
+        get() = webInfoData
 
     actual val isWeb: Boolean
-        get() = false
+        get() = true
 
 }
 

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/UAParser.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/UAParser.kt
@@ -1,0 +1,49 @@
+package com.devx.kdeviceinfo.model
+
+@JsModule("ua-parser-js")
+external class UAParser(
+    userAgent: String
+) {
+
+    fun getResult(): UAParserResult
+
+}
+
+external interface UAParserResult {
+    val browser: Browser
+    val cpu: CPU
+    val device: Device
+    val engine: Engine
+    val os: Os
+}
+
+external interface Browser {
+    val name: String?
+    val version: String?
+}
+
+external interface CPU {
+    val architecture: String?
+}
+
+external interface Device {
+    val model: String?
+    val type: String?
+    val vendor: String?
+}
+
+external interface Engine {
+    val name: String?
+    val version: String?
+}
+
+external interface Os {
+    val name: String?
+    val version: String?
+}
+
+fun parseUserAgent(
+    userAgent: String
+): UAParserResult {
+    return UAParser(userAgent).getResult()
+}

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/WebInfoImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/WebInfoImpl.kt
@@ -1,0 +1,52 @@
+package com.devx.kdeviceinfo.model
+
+import com.devx.kdeviceinfo.model.browser.BrowserImpl
+import com.devx.kdeviceinfo.model.cpu.CPUImpl
+import com.devx.kdeviceinfo.model.device.DeviceImpl
+import com.devx.kdeviceinfo.model.engine.EngineImpl
+import com.devx.kdeviceinfo.model.operatingsystem.OsImpl
+import com.devx.kdeviceinfo.model.web.WebInfo
+import com.devx.kdeviceinfo.model.web.browser.Browser
+import com.devx.kdeviceinfo.model.web.cpu.CPU
+import com.devx.kdeviceinfo.model.web.device.Device
+import com.devx.kdeviceinfo.model.web.engine.Engine
+import com.devx.kdeviceinfo.model.web.operatingsystem.Os
+import kotlinx.browser.window
+
+class WebInfoImpl : WebInfo {
+
+    override val userAgent: String
+        get() = window.navigator.userAgent
+
+    override val browser: Browser
+
+    override val cpu: CPU
+
+    override val device: Device
+
+    override val engine: Engine
+
+    override val os: Os
+
+    init {
+        val result = UAParser(
+            userAgent = userAgent
+        ).getResult()
+        browser = BrowserImpl(
+           parsedBrowser = result.browser
+        )
+        cpu = CPUImpl(
+            parsedCPU = result.cpu
+        )
+        device = DeviceImpl(
+            parsedDevice = result.device
+        )
+        engine = EngineImpl(
+            parsedEngine = result.engine
+        )
+        os = OsImpl(
+            parsedOs = result.os
+        )
+    }
+
+}

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/WebInfoImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/WebInfoImpl.kt
@@ -15,8 +15,7 @@ import kotlinx.browser.window
 
 class WebInfoImpl : WebInfo {
 
-    override val userAgent: String
-        get() = window.navigator.userAgent
+    override val userAgent: String = window.navigator.userAgent
 
     override val browser: Browser
 

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/browser/BrowserImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/browser/BrowserImpl.kt
@@ -1,0 +1,15 @@
+package com.devx.kdeviceinfo.model.browser
+
+import com.devx.kdeviceinfo.model.web.browser.Browser
+
+class BrowserImpl(
+    private val parsedBrowser: com.devx.kdeviceinfo.model.Browser
+) : Browser {
+
+    override val name: String
+        get() = parsedBrowser.name.safeValue()
+
+    override val version: String
+        get() = parsedBrowser.version.safeValue()
+
+}

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/cpu/CPUImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/cpu/CPUImpl.kt
@@ -1,0 +1,12 @@
+package com.devx.kdeviceinfo.model.cpu
+
+import com.devx.kdeviceinfo.model.web.cpu.CPU
+
+class CPUImpl(
+    private val parsedCPU: com.devx.kdeviceinfo.model.CPU
+) : CPU {
+
+    override val architecture: String
+        get() = parsedCPU.architecture.safeValue()
+
+}

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/device/DeviceImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/device/DeviceImpl.kt
@@ -1,0 +1,18 @@
+package com.devx.kdeviceinfo.model.device
+
+import com.devx.kdeviceinfo.model.web.device.Device
+
+class DeviceImpl(
+    private val parsedDevice: com.devx.kdeviceinfo.model.Device
+) : Device {
+
+    override val model: String
+        get() = parsedDevice.model.safeValue()
+
+    override val type: String
+        get() = parsedDevice.type.safeValue()
+
+    override val vendor: String
+        get() = parsedDevice.vendor.safeValue()
+
+}

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/engine/EngineImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/engine/EngineImpl.kt
@@ -1,0 +1,15 @@
+package com.devx.kdeviceinfo.model.engine
+
+import com.devx.kdeviceinfo.model.web.engine.Engine
+
+class EngineImpl(
+    private val parsedEngine: com.devx.kdeviceinfo.model.Engine
+) : Engine {
+
+    override val name: String
+        get() = parsedEngine.name.safeValue()
+
+    override val version: String
+        get() = parsedEngine.version.safeValue()
+
+}

--- a/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/operatingsystem/OsImpl.kt
+++ b/KDeviceInfo/src/wasmJsMain/kotlin/com/devx/kdeviceinfo/model/operatingsystem/OsImpl.kt
@@ -1,0 +1,15 @@
+package com.devx.kdeviceinfo.model.operatingsystem
+
+import com.devx.kdeviceinfo.model.web.operatingsystem.Os
+
+class OsImpl(
+    private val parsedOs : com.devx.kdeviceinfo.model.Os
+) : Os {
+
+    override val name: String
+        get() = parsedOs.name.safeValue()
+
+    override val version: String
+        get() = parsedOs.version.safeValue()
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Plugin Versions
 kotlin = "2.0.21"
-androidGrdlePlugin = "8.6.0-alpha07"
+androidGrdlePlugin = "8.7.2"
 jetbrainsCompose = "1.7.1"
 mavenPublish = "0.30.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 # Plugin Versions
 kotlin = "2.0.21"
-androidGrdlePlugin = "8.7.2"
+androidGrdlePlugin = "8.6.0-alpha07"
 jetbrainsCompose = "1.7.1"
 mavenPublish = "0.30.0"
 
 # Library Versions
 annotation = "1.9.1"
+oshiCore = "6.6.5"
 startupRuntime = "1.2.0"
 androidXCore = "1.13.1"
 
@@ -20,10 +21,12 @@ kDeviceInfo = "0.0.7"
 [libraries]
 # KDeviceInfo module libraries
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidXCore" }
+oshi-core = { module = "com.github.oshi:oshi-core", version.ref = "oshiCore" }
 startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "startupRuntime" }
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jetbrainsCompose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrainsCompose" }
+x_cdn-jsdelivr-net_npm_ua-parser-js = { module = "https://cdn.jsdelivr.net/npm/ua-parser-js" }
 
 # sampleApp module libraries
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # Plugin Versions
 kotlin = "2.0.21"
-androidGrdlePlugin = "8.7.2"
+androidGrdlePlugin = "8.6.0-alpha07"
 jetbrainsCompose = "1.7.1"
 mavenPublish = "0.30.0"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,7 +26,6 @@ startup-runtime = { module = "androidx.startup:startup-runtime", version.ref = "
 androidx-annotation = { module = "androidx.annotation:annotation", version.ref = "annotation" }
 compose-ui = { module = "org.jetbrains.compose.ui:ui", version.ref = "jetbrainsCompose" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "jetbrainsCompose" }
-x_cdn-jsdelivr-net_npm_ua-parser-js = { module = "https://cdn.jsdelivr.net/npm/ua-parser-js" }
 
 # sampleApp module libraries
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidxAppcompat" }

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
@@ -16,6 +16,7 @@ import com.devx.kdeviceinfo.DeviceInfoXState
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
+import com.devx.kdeviceinfo.model.web.WebInfo
 import com.devx.kdeviceinfo.rememberDeviceInfoXState
 import com.devx.kdeviceinfo.sample.theme.AppTheme
 
@@ -41,7 +42,9 @@ internal fun App() = AppTheme {
             } else if(deviceInfoXState.isDesktop) {
                 ShowDesktopDeviceInfo(desktopInfo = deviceInfoXState.desktopInfo)
             } else {
-                Text(text = "Welcome to Web App")
+                ShowWebDeviceInfo(
+                    webInfo = deviceInfoXState.webInfo
+                )
             }
         }
     }
@@ -193,5 +196,56 @@ private fun ShowDesktopDeviceInfo(desktopInfo: DesktopInfo) {
             }
             Text(text = "Ram size: ${hardware.globalMemory.total} bytes")
         }
+    }
+}
+
+@Composable
+private fun ShowWebDeviceInfo(
+    webInfo: WebInfo
+) {
+    val verticalScrollState = rememberScrollState()
+
+    Column(modifier = Modifier.verticalScroll(state = verticalScrollState)) {
+
+        // Browser Info
+        val userAgent = webInfo.userAgent
+        Text(text = "User Agent Info", style = TextStyle(fontSize = 20.sp))
+        Text(text = "UA : $userAgent")
+        Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
+
+        // Browser Info
+        val browser = webInfo.browser
+        Text(text = "Browser Info", style = TextStyle(fontSize = 20.sp))
+        Text(text = "Name : ${browser.name}")
+        Text(text = "Version : ${browser.version}")
+        Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
+
+        // Device Info
+        val device = webInfo.device
+        Text(text = "Device Info", style = TextStyle(fontSize = 20.sp))
+        Text(text = "Model : ${device.model}")
+        Text(text = "Type : ${device.type}")
+        Text(text = "Vendor : ${device.vendor}")
+        Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
+
+        // Engine Info
+        val engine = webInfo.engine
+        Text(text = "Engine Info", style = TextStyle(fontSize = 20.sp))
+        Text(text = "Name : ${engine.name}")
+        Text(text = "Version : ${engine.version}")
+        Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
+
+        // Engine Info
+        val os = webInfo.os
+        Text(text = "Operating System Info", style = TextStyle(fontSize = 20.sp))
+        Text(text = "Name : ${os.name}")
+        Text(text = "Version : ${os.version}")
+        Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
+
+        // Engine Info
+        val cpu = webInfo.cpu
+        Text(text = "CPU Info", style = TextStyle(fontSize = 20.sp))
+        Text(text = "Architecture : ${cpu.architecture}")
+        Spacer(modifier = Modifier.fillMaxWidth().height(height = 20.dp))
     }
 }

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/App.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.devx.kdeviceinfo.DeviceInfoXState
+import com.devx.kdeviceinfo.OnPlatform
 import com.devx.kdeviceinfo.model.android.AndroidInfo
 import com.devx.kdeviceinfo.model.desktop.DesktopInfo
 import com.devx.kdeviceinfo.model.ios.IosInfo
@@ -35,17 +36,19 @@ internal fun App() = AppTheme {
                 .padding(paddingValues = it)
                 .padding(horizontal = 16.dp)
         ) {
-            if (deviceInfoXState.isAndroid) {
-                ShowAndroidDeviceInfo(androidInfo = deviceInfoXState.androidInfo)
-            } else if (deviceInfoXState.isIos) {
-                ShowIosDeviceInfo(iosInfo = deviceInfoXState.iosInfo)
-            } else if(deviceInfoXState.isDesktop) {
-                ShowDesktopDeviceInfo(desktopInfo = deviceInfoXState.desktopInfo)
-            } else {
-                ShowWebDeviceInfo(
-                    webInfo = deviceInfoXState.webInfo
-                )
-            }
+            OnPlatform(
+                deviceInfoXState = deviceInfoXState,
+                onAndroid = { androidInfo ->
+                    ShowAndroidDeviceInfo(androidInfo = androidInfo)
+                },
+                onIos = { iosInfo ->
+                    ShowIosDeviceInfo(iosInfo = iosInfo)
+                },
+                onDesktop = { desktopInfo ->
+                    ShowDesktopDeviceInfo(desktopInfo = desktopInfo)
+                },
+                onWeb =  { webInfo -> ShowWebDeviceInfo(webInfo = webInfo) }
+            )
         }
     }
 }

--- a/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/AppViewModel.kt
+++ b/sampleApp/composeApp/src/commonMain/kotlin/com/devx/kdeviceinfo/sample/AppViewModel.kt
@@ -18,6 +18,9 @@ class AppViewModel {
         } else if(deviceInfoXState.isDesktop) {
             val desktopInfo = deviceInfoXState.desktopInfo
             println("DeviceInfoX - System Name : ${desktopInfo.operatingSystem.versionInfo.version}")
+        } else if(deviceInfoXState.isWeb) {
+            val webInfo = deviceInfoXState.webInfo
+            println("DeviceInfoX - System Name : ${webInfo.os.version}")
         }
     }
 }

--- a/sampleApp/composeApp/src/wasmJsMain/kotlin/main.kt
+++ b/sampleApp/composeApp/src/wasmJsMain/kotlin/main.kt
@@ -1,0 +1,11 @@
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import com.devx.kdeviceinfo.sample.App
+import kotlinx.browser.document
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+    ComposeViewport(document.body!!) {
+        App()
+    }
+}

--- a/sampleApp/composeApp/src/wasmJsMain/resources/index.html
+++ b/sampleApp/composeApp/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>AmetistaEngineDemo</title>
+    <link type="text/css" rel="stylesheet" href="styles.css">
+    <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/sampleApp/composeApp/src/wasmJsMain/resources/styles.css
+++ b/sampleApp/composeApp/src/wasmJsMain/resources/styles.css
@@ -1,0 +1,7 @@
+html, body {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    padding: 0;
+    overflow: hidden;
+}


### PR DESCRIPTION
Integrated the `wasm` target integration based on the `JS` [ua-parser](https://github.com/faisalman/ua-parser-js) library.
I have refactored the `DeviceInfoXExt.kt` adding also the `desktop` and the `wasm` targets to execute the related `OnPlatform` and `onPlatform` branch